### PR TITLE
Create Imagine_Dragons_May_29_2022_Scoppy_Recorded_by_DanD folder

### DIFF
--- a/raw_wild_ir_captures/Imagine_Dragons_May_29_2022_Scoppy_Recorded_by_DanD
+++ b/raw_wild_ir_captures/Imagine_Dragons_May_29_2022_Scoppy_Recorded_by_DanD
@@ -1,0 +1,1 @@
+Recordings usin Scoppy on Android and a Raspberry Pi Pico as capture interface for an IR sensor


### PR DESCRIPTION
Create folder to store Scoppy IR captures from Imagine Dragons concert on May 2022.