### PR TITLE
Initialize SKIP_FIRST_N_CODES

### DIFF
--- a/ir_code_discovery_and_export/brute_force_gui.py
+++ b/ir_code_discovery_and_export/brute_force_gui.py
@@ -25,6 +25,9 @@ ARDUINO_BAUD_RATE = 115200
 # You may want to disable this if you are looking for probabilistic effects, or you have tried so many codes that memory
 # usage becomes a problem. Attempted codes are stored in "brute_already_tried.pickle".
 SKIP_ALREADY_TRIED = True
+
+# Change this to skip the first N codes in the sequence (used in the case that you are resuming
+# from a previous brute forcing attempt)
 SKIP_FIRST_N_CODES = 0
 
 ############################################################

--- a/ir_code_discovery_and_export/brute_force_gui.py
+++ b/ir_code_discovery_and_export/brute_force_gui.py
@@ -25,6 +25,7 @@ ARDUINO_BAUD_RATE = 115200
 # You may want to disable this if you are looking for probabilistic effects, or you have tried so many codes that memory
 # usage becomes a problem. Attempted codes are stored in "brute_already_tried.pickle".
 SKIP_ALREADY_TRIED = True
+SKIP_FIRST_N_CODES = 0
 
 ############################################################
 layout = [[sg.Text("", key="scan_text")],


### PR DESCRIPTION
# Description

The variable SKIP_FIRST_N_CODES is not initialized, and it should be initialized to 0 so it does not cause an error.

Fixes [part of this comment in issue #10 ](https://github.com/danielweidman/pixmob-ir-reverse-engineering/issues/10#issuecomment-1355724786)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I ran the file `brute_force_gui.py` before making this change and it did not run. I ran it after adding this line and it works. 

**Test Configuration**:
* Hardware: D1 Mini ESP8266 clone with IR transmitter connected via breadboard
* Software: Python 3.10.7
* OS: Ubuntu 22.10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules