### PR TITLE
Add nrz-i conversion functions

### DIFF
--- a/python_tools/flipper_file_to_ones_and_zeroes.py
+++ b/python_tools/flipper_file_to_ones_and_zeroes.py
@@ -95,4 +95,4 @@ if __name__ == "__main__":
     mega_list = get_all_found_flipper_codes(root_dir)
     for code in mega_list:
         print(code)
-    send_list_of_codes(mega_list)
+    send_list_of_codes(mega_list, wait=True)

--- a/python_tools/pixmob_conversion_funcs.py
+++ b/python_tools/pixmob_conversion_funcs.py
@@ -77,3 +77,28 @@ def bits_to_arduino_string(bit_list):
     return out + ","
 
 
+def bits_to_nrzi(bit_list, convention="space"):
+    if convention.lower() == "mark":
+        same = 0
+        change = 1
+    elif convention.lower() == "space":
+        same = 1
+        change = 0
+    else:
+        raise ValueError("Convention must be space or mark")
+
+    previous = bit_list[0]
+    nrzi_bits = [change]
+    for bit in bit_list[1:]:
+        if bit==previous:
+            nrzi_bits.append(same)
+        else:
+            nrzi_bits.append(change)
+        previous = bit
+    return nrzi_bits
+
+def bit_list_to_bit_string(bit_list):
+    return "".join([str(bit) for bit in bit_list])
+
+def invert(bit_list):
+    return [(i+1)%2 for i in bit_list]

--- a/python_tools/send.py
+++ b/python_tools/send.py
@@ -3,20 +3,32 @@ import python_tools.pixmob_conversion_funcs as funcs
 import python_tools.config as cfg
 
 
-def send_one_code(code, arduino=None):
+def send_one_code(code, arduino=None, wait=False):
+    """
+    Take in a bit list and send it to an arduino. If arduino is not set, then initialize a new serial connection.
+    Wait is a boolean that says whether to wait for user input before proceeding between codes. It's set to false by
+    default because if you're calling this to send one code, you probably just want it to send.
+    """
     if arduino is None:
         arduino = serial.Serial(port=cfg.ARDUINO_SERIAL_PORT, baudrate=cfg.ARDUINO_BAUD_RATE, timeout=.1)
     try:
         print(code)
+        if wait:
+            input("Press enter to send")
         arduino_string_ver = funcs.bits_to_arduino_string(code)
         arduino.write(bytes(arduino_string_ver, 'utf-8'))
-        input("Press enter for next")
         print("Command sent to Arduino.")
     except ValueError as e:
         print(e)
 
 
-def send_list_of_codes(code_list):
+def send_list_of_codes(code_list, wait=True):
+    """
+    Take in a list of bit lists and send it to an arduino. If arduino is not set, then initialize a new serial
+    connection and use that for the whole list.
+    Wait is a boolean that says whether to wait for user input before proceeding. It's set to True by default,
+    because in a list of codes, you probably want to see each code individually.
+    """
     arduino = serial.Serial(port=cfg.ARDUINO_SERIAL_PORT, baudrate=cfg.ARDUINO_BAUD_RATE, timeout=.1)
     for code in code_list:
-        send_one_code(code, arduino)
+        send_one_code(code, arduino, wait=wait)


### PR DESCRIPTION
I just checked and the IR signal is encoded in such a way that it contains the same information if all the bits are flipped. The LED of my wristband lights up red both times I send a code in the following test:

```
import python_tools.pixmob_conversion_funcs as funcs
import python_tools.effect_definitions as effects
from python_tools.send import send_one_code

send_one_code(effects.base_color_effects["RED"], wait=True)
send_one_code(funcs.invert(effects.base_color_effects["RED"]), wait=True)
```

That makes me pretty sure the IR signal is encoded with some kind of NRZ-I (non-return to zero inverted) code. This means that the data in encoded in bits represented by a change in the signal or no change in the signal at clock/pulse/chip boundaries. "NRZ-I Mark" would mean that a one is encoded by a transition, and zero by it remaining the same. "NRZ-I Space" would be the opposite (0 is a transtion, 1 is staying the same). It's possible there is some other encoding scheme that also fits with this new property and the rest of what we've learned, but I haven't found one yet. More information here: https://en.wikipedia.org/wiki/Non-return-to-zero

So, I added a conversion function to make it easier to analyze the signals in this format. Hopefully the structure of the data will be more apparent in this way!