### PR TITLE
Add pico_sender (serial example for Raspberry Pi Pico)

### DIFF
--- a/pico_sender/PixMob_Transmitter_Pico/main.py
+++ b/pico_sender/PixMob_Transmitter_Pico/main.py
@@ -1,0 +1,43 @@
+from machine import Pin, PWM
+from time import sleep_us
+
+import select
+import sys
+
+poll_obj = select.poll()
+poll_obj.register(sys.stdin, select.POLLIN)
+
+ir_pin = Pin(15, Pin.OUT)  # set this to the data pin used for the IR LED
+ir_led = PWM(ir_pin)
+ir_led.freq(38000)
+
+
+def read_until(until_char, keep_result=True):
+    result = ''
+    while True:
+        char = sys.stdin.read(1)
+        if char == until_char:
+            break
+
+        if keep_result:
+            result += char
+    return result
+
+
+def send_raw_ir_command(command, ir_pin):
+    for i in range(len(command)):
+        duration = int(command[i]) * 700
+        if i % 2 == 0:
+            ir_pin.duty_u16(32768)  # 50% duty cycle
+        else:  # Odd index (space)
+            ir_pin.duty_u16(0)
+        sleep_us(duration)
+    ir_pin.deinit()
+
+
+while True:
+    poll_results = poll_obj.poll(1)
+    if poll_results:
+        read_until(']', False)
+        command = read_until(',')
+        send_raw_ir_command(command, ir_led)

--- a/pico_sender/README.md
+++ b/pico_sender/README.md
@@ -1,0 +1,7 @@
+This folder contains the code for a [Raspberry Pi Pico](https://www.raspberrypi.com/documentation/microcontrollers/pico-series.html) that will listen for commands over serial from a computer and then transmit those IR commands with an attached IR transmitter.
+
+You need to have a simple IR transmitter circuit set up with your Pico. This can be accomplished with a board like [this](https://www.amazon.com/Digital-Receiver-Transmitter-Arduino-Compatible/dp/B01E20VQD8/) or an IR LED with a resistor and/or transistor. Many tutorials are available for the simple circuit.
+
+The Pico code is written in MicroPython, which means that you need to have MicroPython set up to execute it. You can either [drag and drop](https://www.raspberrypi.com/documentation/microcontrollers/micropython.html#drag-and-drop-micropython) MicroPython onto your Pico or install it [using Thonny](https://projects.raspberrypi.org/en/projects/getting-started-with-the-pico/3). 
+
+Once you write the [main.py file](PixMob_Transmitter_Pico/main.py) to your Pico, it is ready to receive commands over serial. The main.py file gets executed automatically once you plug your Pico in.


### PR DESCRIPTION
I created a MicroPython script for the Raspberry Pi Pico that uses the serial input from the demo Python files to send the commands over IR. It understands the same commands as the arduino_sender examples, meaning a Pico with this code is a drop in replacement for an Arduino with the arduino_sender code.

A Raspberry Pi Pico is really easy to get, which is why I think having Pico code available is a valuable addition to the repository.